### PR TITLE
For first

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,16 @@
       "test/DataProviders.php",
       "test/Warnings.php",
       "test/ClassWithToString.php",
-      "test/ClosureMock.php"
+      "test/ClosureMock.php",
+      "test/Utils/ClassWithDefaultConstructor.php",
+      "test/Utils/ClassWithErrorInConstructor.php",
+      "test/Utils/ClassWithoutSuitableConstructor.php",
+      "test/Utils/ClassWithStringParamConstructor.php",
+      "test/Utils/ClassWithTwoStringParamsConstructor.php"
     ],
     "psr-0": {
       "CleanRegex\\": "src",
-      "SafeRegex\\": "src",
-      "CleanRegex\\Test\\": "test",
-      "SafeRegex\\Test\\": "test"
+      "SafeRegex\\": "src"
     }
   },
   "require": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit>
+<phpunit bootstrap="vendor/autoload.php">
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>

--- a/src/CleanRegex/Exception/CleanRegex/ClassExpectedException.php
+++ b/src/CleanRegex/Exception/CleanRegex/ClassExpectedException.php
@@ -1,0 +1,25 @@
+<?php
+namespace CleanRegex\Exception\CleanRegex;
+
+class ClassExpectedException extends CleanRegexException
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function notFound(string $className): ClassExpectedException
+    {
+        return new ClassExpectedException("Class '$className' does not exists");
+    }
+
+    public static function notThrowable(string $className)
+    {
+        return new ClassExpectedException("Class '$className' is not throwable");
+    }
+
+    public static function isInterface(string $className)
+    {
+        return new ClassExpectedException("'$className' is not a class, but an interface");
+    }
+}

--- a/src/CleanRegex/Exception/CleanRegex/NoSuitableConstructorException.php
+++ b/src/CleanRegex/Exception/CleanRegex/NoSuitableConstructorException.php
@@ -1,0 +1,10 @@
+<?php
+namespace CleanRegex\Exception\CleanRegex;
+
+class NoSuitableConstructorException extends CleanRegexException
+{
+    public function __construct(string $className)
+    {
+        parent::__construct("Class '$className' doesn't have a constructor with supported signature");
+    }
+}

--- a/src/CleanRegex/Exception/CleanRegex/SubjectNotMatchedException.php
+++ b/src/CleanRegex/Exception/CleanRegex/SubjectNotMatchedException.php
@@ -3,6 +3,8 @@ namespace CleanRegex\Exception\CleanRegex;
 
 class SubjectNotMatchedException extends CleanRegexException
 {
+    public const MESSAGE = 'Expected to get first match in the subject, but subject was not matched at all';
+
     /** @var string */
     private $subject; // Debugger
 
@@ -14,7 +16,6 @@ class SubjectNotMatchedException extends CleanRegexException
 
     public static function forFirst(string $subject): SubjectNotMatchedException
     {
-        $message = 'Tried to get first match in the subject, but subject was not matched at all';
-        return new SubjectNotMatchedException($message, $subject);
+        return new SubjectNotMatchedException(self::MESSAGE, $subject);
     }
 }

--- a/src/CleanRegex/Internal/UnknownSignatureExceptionFactory.php
+++ b/src/CleanRegex/Internal/UnknownSignatureExceptionFactory.php
@@ -1,0 +1,87 @@
+<?php
+namespace CleanRegex\Internal;
+
+use ArgumentCountError;
+use CleanRegex\Exception\CleanRegex\ClassExpectedException;
+use CleanRegex\Exception\CleanRegex\NoSuitableConstructorException;
+use CleanRegex\Exception\CleanRegex\SubjectNotMatchedException;
+use Error;
+use Throwable;
+use TypeError;
+
+class UnknownSignatureExceptionFactory
+{
+    /** @var string */
+    private $className;
+
+    public function __construct(string $className)
+    {
+        $this->className = $className;
+    }
+
+    public function create(string $subject): Throwable
+    {
+        $this->validateClassExists();
+        $exception = $this->tryCreate($subject);
+        if ($exception instanceof Throwable) {
+            return $exception;
+        }
+        throw ClassExpectedException::notThrowable($this->className);
+    }
+
+    private function validateClassExists(): void
+    {
+        if (!class_exists($this->className)) {
+            throw ClassExpectedException::notFound($this->className);
+        }
+    }
+
+    /**
+     * @param string $subject
+     * @return mixed
+     * @throws NoSuitableConstructorException
+     */
+    private function tryCreate(string $subject)
+    {
+        foreach ($this->getSignatures($subject) as $signature) {
+            try {
+                return $signature();
+            } catch (ArgumentCountError $error) {
+                continue;
+            } catch (TypeError $error) {
+                continue;
+            } catch (Error $error) {
+                if ($this->isWrongParametersError($error)) {
+                    continue;
+                }
+                throw $error;
+            }
+        }
+        throw new NoSuitableConstructorException($this->className);
+    }
+
+    private function getSignatures(string $subject): array
+    {
+        return [
+            function () use ($subject) {
+                return new $this->className(SubjectNotMatchedException::MESSAGE, $subject);
+            },
+            function () use ($subject) {
+                return new $this->className(SubjectNotMatchedException::MESSAGE);
+            },
+            function () use ($subject) {
+                return new $this->className();
+            }
+        ];
+    }
+
+    private function isWrongParametersError(Error $error): bool
+    {
+        return $this->startsWith($error->getMessage(), "Wrong parameters for $this->className");
+    }
+
+    private function startsWith(string $haystack, string $needle)
+    {
+        return substr($haystack, 0, strlen($needle)) === $needle;
+    }
+}

--- a/src/CleanRegex/Match/Details/Details.php
+++ b/src/CleanRegex/Match/Details/Details.php
@@ -1,0 +1,18 @@
+<?php
+namespace CleanRegex\Match\Details;
+
+interface Details
+{
+    public function subject(): string;
+
+    /**
+     * @return string[]
+     */
+    public function groupNames(): array;
+
+    /**
+     * @param string|int $nameOrIndex
+     * @return bool
+     */
+    public function hasGroup($nameOrIndex): bool;
+}

--- a/src/CleanRegex/Match/Details/Match.php
+++ b/src/CleanRegex/Match/Details/Match.php
@@ -12,7 +12,7 @@ use function array_values;
 use function is_int;
 use function is_string;
 
-class Match
+class Match implements Details
 {
     /** @var integer */
     protected const WHOLE_MATCH = 0;
@@ -55,12 +55,10 @@ class Match
     public function group($nameOrIndex): ?string
     {
         $this->validateGroupName($nameOrIndex);
-
         if ($this->hasGroup($nameOrIndex)) {
             list($match, $offset) = $this->matches[$nameOrIndex][$this->index];
             return $match;
         }
-
         throw new NonexistentGroupException($nameOrIndex);
     }
 
@@ -70,14 +68,12 @@ class Match
     public function namedGroups(): array
     {
         $namedGroups = [];
-
         foreach ($this->matches as $groupNameOrIndex => $match) {
             if (is_string($groupNameOrIndex)) {
                 list($value, $offset) = $match[$this->index];
                 $namedGroups[$groupNameOrIndex] = $value;
             }
         }
-
         return $namedGroups;
     }
 

--- a/src/CleanRegex/Match/Details/NotMatched.php
+++ b/src/CleanRegex/Match/Details/NotMatched.php
@@ -1,0 +1,40 @@
+<?php
+namespace CleanRegex\Match\Details;
+
+class NotMatched implements Details
+{
+    /** @var array */
+    private $matches;
+    /** @var string */
+    private $subject;
+
+    public function __construct(array $matches, string $subject)
+    {
+        $this->matches = $matches;
+        $this->subject = $subject;
+    }
+
+    public function subject(): string
+    {
+        return $this->subject;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function groupNames(): array
+    {
+        return array_values(array_filter(array_keys($this->matches), function ($key) {
+            return is_string($key);
+        }));
+    }
+
+    /**
+     * @param string|int $nameOrIndex
+     * @return bool
+     */
+    public function hasGroup($nameOrIndex): bool
+    {
+        return array_key_exists($nameOrIndex, $this->matches);
+    }
+}

--- a/src/CleanRegex/Match/ForFirst/MatchedOptional.php
+++ b/src/CleanRegex/Match/ForFirst/MatchedOptional.php
@@ -1,0 +1,42 @@
+<?php
+namespace CleanRegex\Match\ForFirst;
+
+use CleanRegex\Exception\CleanRegex\SubjectNotMatchedException;
+
+class MatchedOptional implements Optional
+{
+    /** @var mixed */
+    private $result;
+
+    public function __construct($result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * @param string $exceptionClassName
+     * @return mixed
+     */
+    public function orThrow(string $exceptionClassName = SubjectNotMatchedException::class)
+    {
+        return $this->result;
+    }
+
+    /**
+     * @param mixed $default
+     * @return mixed
+     */
+    public function orReturn($default)
+    {
+        return $this->result;
+    }
+
+    /**
+     * @param callable $producer
+     * @return mixed
+     */
+    public function orElse(callable $producer)
+    {
+        return $this->result;
+    }
+}

--- a/src/CleanRegex/Match/ForFirst/NotMatchedOptional.php
+++ b/src/CleanRegex/Match/ForFirst/NotMatchedOptional.php
@@ -1,0 +1,54 @@
+<?php
+namespace CleanRegex\Match\ForFirst;
+
+use CleanRegex\Exception\CleanRegex\SubjectNotMatchedException;
+use CleanRegex\Internal\UnknownSignatureExceptionFactory;
+use CleanRegex\Match\Details\NotMatched;
+use Throwable;
+
+class NotMatchedOptional implements Optional
+{
+    /** @var array */
+    private $matches;
+    /** @var string */
+    private $subject;
+
+    public function __construct(array $matches, string $subject)
+    {
+        $this->matches = $matches;
+        $this->subject = $subject;
+    }
+
+    /**
+     * @param string $exceptionClassName
+     * @throws Throwable
+     */
+    public function orThrow(string $exceptionClassName = SubjectNotMatchedException::class)
+    {
+        $exception = $this->getException($exceptionClassName);
+        throw $exception;
+    }
+
+    private function getException(string $exceptionClassName): Throwable
+    {
+        return (new UnknownSignatureExceptionFactory($exceptionClassName))->create($this->subject);
+    }
+
+    /**
+     * @param mixed $default
+     * @return mixed
+     */
+    public function orReturn($default)
+    {
+        return $default;
+    }
+
+    /**
+     * @param callable $producer
+     * @return mixed
+     */
+    public function orElse(callable $producer)
+    {
+        return call_user_func($producer, new NotMatched($this->matches, $this->subject));
+    }
+}

--- a/src/CleanRegex/Match/ForFirst/Optional.php
+++ b/src/CleanRegex/Match/ForFirst/Optional.php
@@ -1,0 +1,26 @@
+<?php
+namespace CleanRegex\Match\ForFirst;
+
+use CleanRegex\Exception\CleanRegex\SubjectNotMatchedException;
+
+interface Optional
+{
+    /**
+     * @param string $exceptionClassName
+     * @return mixed
+     * @throws \Throwable|SubjectNotMatchedException
+     */
+    public function orThrow(string $exceptionClassName = SubjectNotMatchedException::class);
+
+    /**
+     * @param mixed $default
+     * @return mixed
+     */
+    public function orReturn($default);
+
+    /**
+     * @param callable $producer
+     * @return mixed
+     */
+    public function orElse(callable $producer);
+}

--- a/src/CleanRegex/Match/MatchPattern.php
+++ b/src/CleanRegex/Match/MatchPattern.php
@@ -7,6 +7,9 @@ use CleanRegex\Internal\GroupNameValidator;
 use CleanRegex\Internal\Pattern;
 use CleanRegex\Internal\PatternLimit;
 use CleanRegex\Match\Details\Match;
+use CleanRegex\Match\ForFirst\MatchedOptional;
+use CleanRegex\Match\ForFirst\NotMatchedOptional;
+use CleanRegex\Match\ForFirst\Optional;
 use CleanRegex\Match\Groups\Strategy\GroupVerifier;
 use CleanRegex\Match\Groups\Strategy\MatchAllGroupVerifier;
 use InvalidArgumentException;
@@ -125,6 +128,21 @@ class MatchPattern implements PatternLimit
         }
         list($value, $offset) = $matches[self::GROUP_WHOLE_MATCH][self::FIRST_MATCH];
         return $value;
+    }
+
+    /**
+     * @param callable $callback
+     * @return Optional
+     */
+    public function forFirst(callable $callback): Optional
+    {
+        $matches = $this->performMatchAll();
+        if (empty($matches[self::GROUP_WHOLE_MATCH])) {
+            return new NotMatchedOptional($matches, $this->subject);
+        }
+
+        $result = $callback(new Match($this->subject, self::FIRST_MATCH, $matches));
+        return new MatchedOptional($result);
     }
 
     /**

--- a/test/Integration/CleanRegex/MatchPatternTest.php
+++ b/test/Integration/CleanRegex/MatchPatternTest.php
@@ -48,13 +48,30 @@ class MatchPatternTest extends TestCase
     /**
      * @test
      */
-    public function shouldModifyFirstReturnValue()
+    public function shouldModifyReturnValue_first()
+    {
+        // when
+        $value = pattern('[A-Z]+')->match('Foo, Bar, Top')->first(function () {
+            return 'Different';
+        });
+
+        // then
+        $this->assertEquals("Different", $value);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldModifyReturnValue_forFirst()
     {
         // when
         $value = pattern('[A-Z]+')
             ->match('Foo, Bar, Top')
-            ->first(function (Match $match) {
+            ->forFirst(function () {
                 return 'Different';
+            })
+            ->orElse(function () {
+                $this->assertFalse(true);
             });
 
         // then

--- a/test/Unit/CleanRegex/Internal/UnknownSignatureExceptionFactoryTest.php
+++ b/test/Unit/CleanRegex/Internal/UnknownSignatureExceptionFactoryTest.php
@@ -1,0 +1,158 @@
+<?php
+namespace CleanRegex\Internal;
+
+use CleanRegex\Exception\CleanRegex\ClassExpectedException;
+use CleanRegex\Exception\CleanRegex\NoSuitableConstructorException;
+use CleanRegex\Exception\CleanRegex\SubjectNotMatchedException;
+use Error;
+use Exception;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Test\Utils\ClassWithDefaultConstructor;
+use Test\Utils\ClassWithoutSuitableConstructor;
+use Test\Utils\ClassWithStringParamConstructor;
+use Test\Utils\ClassWithTwoStringParamsConstructor;
+use Utils\ClassWithErrorInConstructor;
+
+class UnknownSignatureExceptionFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldThrow_onNotExistingClass()
+    {
+        // given
+        $factory = new UnknownSignatureExceptionFactory('Namespace\NoSuchClass');
+
+        // then
+        $this->expectException(ClassExpectedException::Class);
+        $this->expectExceptionMessage("Class 'Namespace\NoSuchClass' does not exists");
+
+        // when
+        $factory->create('');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldThrow_onClassThatIsNotThrowable()
+    {
+        // given
+        $factory = new UnknownSignatureExceptionFactory(stdClass::class);
+
+        // then
+        $this->expectException(ClassExpectedException::Class);
+        $this->expectExceptionMessage("Class 'stdClass' is not throwable");
+
+        // when
+        $factory->create('');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldThrow_onClassWithoutSuitableConstructor()
+    {
+        // given
+        $factory = new UnknownSignatureExceptionFactory(ClassWithoutSuitableConstructor::class);
+
+        // then
+        $this->expectException(NoSuitableConstructorException::Class);
+        $this->expectExceptionMessage("Class 'Test\Utils\ClassWithoutSuitableConstructor' doesn't have a constructor with supported signature");
+
+        // when
+        $factory->create('');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldInstantiate_withMessageAndSubjectParams()
+    {
+        // given
+        $factory = new UnknownSignatureExceptionFactory(ClassWithTwoStringParamsConstructor::class);
+
+        // when
+        /** @var ClassWithTwoStringParamsConstructor $exception */
+        $exception = $factory->create('my subject');
+
+        // then
+        $this->assertInstanceOf(ClassWithTwoStringParamsConstructor::class, $exception);
+        $this->assertEquals(SubjectNotMatchedException::MESSAGE, $exception->getMessage());
+        $this->assertEquals('my subject', $exception->getSubject());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldInstantiate_withMessageParam()
+    {
+        // given
+        $factory = new UnknownSignatureExceptionFactory(ClassWithStringParamConstructor::class);
+
+        // when
+        $exception = $factory->create('my subject');
+
+        // then
+        $this->assertInstanceOf(ClassWithStringParamConstructor::class, $exception);
+        $this->assertEquals(SubjectNotMatchedException::MESSAGE, $exception->getMessage());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldInstantiate_withDefaultConstructor()
+    {
+        // given
+        $factory = new UnknownSignatureExceptionFactory(ClassWithDefaultConstructor::class);
+
+        // when
+        $exception = $factory->create('my subject');
+
+        // then
+        $this->assertInstanceOf(ClassWithDefaultConstructor::class, $exception);
+    }
+
+    /**
+     * @test
+     * @dataProvider exceptions
+     * @param string $className
+     */
+    public function shouldInstantiate_withMessage(string $className)
+    {
+        // given
+        $factory = new UnknownSignatureExceptionFactory($className);
+
+        // when
+        $exception = $factory->create('my subject');
+
+        // then
+        $this->assertInstanceOf($className, $exception);
+        $this->assertEquals(SubjectNotMatchedException::MESSAGE, $exception->getMessage());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRethrow_errorWhileInstantiating()
+    {
+        // given
+        $factory = new UnknownSignatureExceptionFactory(ClassWithErrorInConstructor::class);
+
+        // then
+        $this->expectException(Error::class);
+
+        // when
+        $factory->create('my subject');
+    }
+
+    public function exceptions()
+    {
+        return [
+            [Exception::class],
+            [InvalidArgumentException::class],
+            [SubjectNotMatchedException::class],
+        ];
+    }
+}

--- a/test/Unit/CleanRegex/Match/MatchPattern/first/MatchPatternTest.php
+++ b/test/Unit/CleanRegex/Match/MatchPattern/first/MatchPatternTest.php
@@ -30,7 +30,7 @@ class MatchPatternTest extends TestCase
     public function shouldGetFirst_withCallback()
     {
         // given
-        $pattern = $this->getMatchPattern("Nice matching pattern");
+        $pattern = $this->getMatchPattern('Nice matching pattern');
 
         // when
         $first = $pattern->first('strrev');
@@ -45,14 +45,13 @@ class MatchPatternTest extends TestCase
     public function shouldGetMatch_withDetails()
     {
         // given
-        $pattern = $this->getMatchPattern("Nice matching pattern");
+        $pattern = $this->getMatchPattern('Nice matching pattern');
 
         // when
         $pattern->first(function (Match $match) {
-
             // then
             $this->assertEquals(0, $match->index());
-            $this->assertEquals("Nice matching pattern", $match->subject());
+            $this->assertEquals('Nice matching pattern', $match->subject());
             $this->assertEquals(['Nice', 'matching', 'pattern'], $match->all());
             $this->assertEquals(['N'], $match->groups());
         });
@@ -70,7 +69,7 @@ class MatchPatternTest extends TestCase
             // when
             $pattern->first(function () {
                 // then
-                $this->assertTrue(false, "Failed asserting that first() is not invoked for not matching subject");
+                $this->assertTrue(false, 'Failed asserting that first() is not invoked for not matching subject');
             });
         } catch (SubjectNotMatchedException $exception) {
             // Ignore

--- a/test/Unit/CleanRegex/Match/MatchPattern/forFirst/MatchPatternTest.php
+++ b/test/Unit/CleanRegex/Match/MatchPattern/forFirst/MatchPatternTest.php
@@ -1,0 +1,204 @@
+<?php
+namespace Test\Unit\CleanRegex\Match\MatchPattern\forFirst;
+
+use CleanRegex\Exception\CleanRegex\SubjectNotMatchedException;
+use CleanRegex\Internal\Pattern;
+use CleanRegex\Match\Details\Match;
+use CleanRegex\Match\Details\NotMatched;
+use CleanRegex\Match\MatchPattern;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class MatchPatternTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldGetMatch_withDetails()
+    {
+        // given
+        $pattern = $this->getMatchPattern("Nice matching pattern");
+
+        // when
+        $pattern
+            ->forFirst(function (Match $match) {
+
+                // then
+                $this->assertEquals(0, $match->index());
+                $this->assertEquals("Nice matching pattern", $match->subject());
+                $this->assertEquals(['Nice', 'matching', 'pattern'], $match->all());
+                $this->assertEquals(['N'], $match->groups());
+            })
+            ->orThrow();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetMatch_withoutCollapsingOrMethod()
+    {
+        // given
+        $pattern = $this->getMatchPattern("Nice matching pattern");
+
+        // when
+        $pattern
+            ->forFirst(function (Match $match) {
+                // then
+                $this->assertEquals("Nice matching pattern", $match->subject());
+            });
+        // ->orThrow();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetFirst()
+    {
+        // given
+        $pattern = $this->getMatchPattern("Nice matching pattern");
+
+        // when
+        $first1 = $pattern->forFirst('strtoupper')->orReturn(null);
+        $first2 = $pattern->forFirst('strtoupper')->orThrow();
+        $first3 = $pattern->forFirst('strtoupper')->orElse(function () {
+        });
+
+        // then
+        $this->assertEquals('NICE', $first1);
+        $this->assertEquals('NICE', $first2);
+        $this->assertEquals('NICE', $first3);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotInvokeFirst_onNotMatchingSubject()
+    {
+        // given
+        $pattern = $this->getMatchPattern('NOT MATCHING');
+
+        // when
+        $pattern->forFirst($this->assertFalseCallback())->orReturn(null);
+        $pattern->forFirst($this->assertFalseCallback())->orElse(function () {
+        });
+        try {
+            @$pattern->forFirst($this->assertFalseCallback())->orThrow();
+        } catch (SubjectNotMatchedException $ignored) {
+        }
+
+        // then
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function should_onNotMatchingSubject_throw()
+    {
+        // given
+        $pattern = $this->getMatchPattern('NOT MATCHING');
+
+        // then
+        $this->expectException(SubjectNotMatchedException::class);
+
+        // when
+        $pattern->forFirst('strrev')->orThrow();
+    }
+
+    /**
+     * @test
+     */
+    public function should_onNotMatchingSubject_throw_userGivenException()
+    {
+        // given
+        $pattern = $this->getMatchPattern('NOT MATCHING');
+
+        // then
+        $this->expectException(InvalidArgumentException::class);
+
+        // when
+        $pattern->forFirst('strrev')->orThrow(InvalidArgumentException::class);
+    }
+
+    /**
+     * @test
+     */
+    public function should_onNotMatchingSubject_throw_withMessage()
+    {
+        // given
+        $pattern = $this->getMatchPattern('NOT MATCHING');
+
+        // then
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(SubjectNotMatchedException::MESSAGE);
+
+        // when
+        $pattern->forFirst('strrev')->orThrow(InvalidArgumentException::class);
+    }
+
+    /**
+     * @test
+     */
+    public function should_onNotMatchingSubject_getDefault()
+    {
+        // given
+        $pattern = $this->getMatchPattern('NOT MATCHING');
+
+        // when
+        $value = $pattern->forFirst('strrev')->orReturn('def');
+
+        // then
+        $this->assertEquals('def', $value);
+    }
+
+    /**
+     * @test
+     */
+    public function should_onNotMatchingSubject_call()
+    {
+        // given
+        $pattern = $this->getMatchPattern('NOT MATCHING');
+
+        // when
+        $value = $pattern->forFirst('strrev')->orElse(function () {
+            return 'new value';
+        });
+
+        // then
+        $this->assertEquals('new value', $value);
+    }
+
+    /**
+     * @test
+     */
+    public function should_onNotMatchingSubject_call_withDetails()
+    {
+        // given
+        $pattern = new MatchPattern(new Pattern("(?:[A-Z])?[a-z']+ (?<group>.)"), 'NOT MATCHING');
+
+        // when
+        $pattern->forFirst('strrev')->orElse(function (NotMatched $details) {
+
+            // then
+            $this->assertEquals('NOT MATCHING', $details->subject());
+            $this->assertEquals(['group'], $details->groupNames());
+            $this->assertTrue($details->hasGroup('group'));
+            $this->assertTrue($details->hasGroup(0));
+            $this->assertTrue($details->hasGroup(1));
+            $this->assertFalse($details->hasGroup('other'));
+            $this->assertFalse($details->hasGroup(2));
+        });
+    }
+
+    private function getMatchPattern($subject): MatchPattern
+    {
+        return new MatchPattern(new Pattern("([A-Z])?[a-z']+"), $subject);
+    }
+
+    private function assertFalseCallback(): callable
+    {
+        return function () {
+            $this->assertTrue(false, "Failed asserting that forFirst() is not invoked for not matching subject");
+        };
+    }
+}

--- a/test/Unit/SafeRegex/Errors/Errors/RuntimeErrorTest.php
+++ b/test/Unit/SafeRegex/Errors/Errors/RuntimeErrorTest.php
@@ -103,6 +103,10 @@ class RuntimeErrorTest extends TestCase
         $this->assertInstanceOf(RuntimeSafeRegexException::class, $exception);
         $this->assertEquals('preg_replace', $exception->getInvokingMethod());
         $this->assertEquals(PREG_BAD_UTF8_ERROR, $exception->getError());
+        $this->assertEquals('PREG_BAD_UTF8_ERROR', $exception->getErrorName());
+        $this->assertEquals('preg_replace', $exception->getInvokingMethod());
+        $this->assertEquals("After invoking preg_replace(), preg_last_error() returned PREG_BAD_UTF8_ERROR.",
+            $exception->getMessage());
     }
 
     /**

--- a/test/Unit/SafeRegex/ExceptionFactoryTest.php
+++ b/test/Unit/SafeRegex/ExceptionFactoryTest.php
@@ -20,13 +20,13 @@ class ExceptionFactoryTest extends TestCase
      * @dataProvider \Test\DataProviders::invalidPregPatterns()
      * @param string $invalidPattern
      */
-    public function testPregErrors(string $invalidPattern)
+    public function testCompileErrors(string $invalidPattern)
     {
         // given
-        $result = @preg_match($invalidPattern, '');
+        @preg_match($invalidPattern, '');
 
         // when
-        $exception = (new ExceptionFactory())->retrieveGlobals('preg_match', $result);
+        $exception = (new ExceptionFactory())->retrieveGlobals('preg_match', false);
 
         // then
         $this->assertInstanceOf(CompileSafeRegexException::class, $exception);
@@ -38,13 +38,13 @@ class ExceptionFactoryTest extends TestCase
      * @param $description
      * @param $utf8
      */
-    public function test(string $description, string $utf8)
+    public function testRuntimeErrors(string $description, string $utf8)
     {
         // given
-        $result = @preg_match("/pattern/u", $utf8);
+        @preg_match("/pattern/u", $utf8);
 
         // when
-        $exception = (new ExceptionFactory())->retrieveGlobals('preg_match', $result);
+        $exception = (new ExceptionFactory())->retrieveGlobals('preg_match', false);
 
         // then
         $this->assertInstanceOf(RuntimeSafeRegexException::class, $exception);
@@ -52,14 +52,11 @@ class ExceptionFactoryTest extends TestCase
 
     /**
      * @test
-     * @dataProvider \Test\DataProviders::invalidPregPatterns()
-     * @param string $invalidPattern
      */
-    public function testUnexpectedReturnError(string $invalidPattern)
+    public function testUnexpectedReturnError()
     {
         // given
-        $result = @preg_match($invalidPattern, '');
-        (new ErrorsCleaner)->clear();
+        $result = false;
 
         // when
         $exception = (new ExceptionFactory())->retrieveGlobals('preg_match', $result);

--- a/test/Utils/ClassWithDefaultConstructor.php
+++ b/test/Utils/ClassWithDefaultConstructor.php
@@ -1,0 +1,8 @@
+<?php
+namespace Test\Utils;
+
+use Exception;
+
+class ClassWithDefaultConstructor extends Exception
+{
+}

--- a/test/Utils/ClassWithErrorInConstructor.php
+++ b/test/Utils/ClassWithErrorInConstructor.php
@@ -1,0 +1,13 @@
+<?php
+namespace Utils;
+
+use Error;
+use Exception;
+
+class ClassWithErrorInConstructor extends Exception
+{
+    public function __construct()
+    {
+        throw new Error();
+    }
+}

--- a/test/Utils/ClassWithStringParamConstructor.php
+++ b/test/Utils/ClassWithStringParamConstructor.php
@@ -1,0 +1,12 @@
+<?php
+namespace Test\Utils;
+
+use Exception;
+
+class ClassWithStringParamConstructor extends Exception
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/test/Utils/ClassWithTwoStringParamsConstructor.php
+++ b/test/Utils/ClassWithTwoStringParamsConstructor.php
@@ -1,0 +1,24 @@
+<?php
+namespace Test\Utils;
+
+use Exception;
+
+class ClassWithTwoStringParamsConstructor extends Exception
+{
+    /** @var string */
+    private $subject;
+
+    public function __construct(string $message, string $subject)
+    {
+        parent::__construct($message);
+        $this->subject = $subject;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSubject(): string
+    {
+        return $this->subject;
+    }
+}

--- a/test/Utils/ClassWithoutSuitableConstructor.php
+++ b/test/Utils/ClassWithoutSuitableConstructor.php
@@ -1,0 +1,11 @@
+<?php
+namespace Test\Utils;
+
+use Exception;
+
+class ClassWithoutSuitableConstructor extends Exception
+{
+    public function __construct(int $a)
+    {
+    }
+}


### PR DESCRIPTION
Before 8c87632db2192912a6397fb619fdb1c3aa717544 methods  `MatchPattern.first()` and `MatchPattern.group(str).first()` returned `null`. That was bad design because unmatched subject was indistinguishable from matched subject with unmatched capturing group.

Since then, they throw `SubjectNotMatchedException` and `GroupNotMatchedException`, which can be caught separately. It also makes for more dull control of optional matches and groups, so this Pull Requests adds to that more options (default value, producer callback and exception). These are `orReturn()`, `orElse` and `orThrow`.

```php
pattern('[A-Z]+')->match($str)->forFirst($map)->orReturn('default value');
pattern('[A-Z]+')->match($str)->forFirst($map)->orElse(function (NotMatched $m) { });
pattern('[A-Z]+')->match($str)->forFirst($map)->orThrow(InvalidArgumentException::class);
```